### PR TITLE
永続的なクッキーの追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -184,3 +184,17 @@ input {
     color: $state-danger-text;
   }
 }
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,12 +3,13 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email].downcase)
-    if user && user.authenticate(params[:session][:password])
+    @user = User.find_by(email: params[:session][:email].downcase)
+    if @user && @user.authenticate(params[:session][:password])
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
-      log_in user
-      remember user
-      redirect_to user # = redirect_to user_url(user)
+      log_in @user
+      # remember_meチェックボックスがオンになっているかどうか
+      params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
+      redirect_to @user # = redirect_to user_url(user)
     else
       # エラーメッセージを作成する
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
       log_in user
+      remember user
       redirect_to user # = redirect_to user_url(user)
     else
       # エラーメッセージを作成する

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,12 +5,33 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  # ユーザーのセッションを永続的にする
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # セッションあればログイン中，セッションがなくてクッキーはあるならばログイン
   def current_user
     # session[:user_id]が存在しないときはnil
-    if session[:user_id]
+    if (user_id = session[:user_id])
       # or equals
-      @current_user ||= User.find_by(id: session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
     end
+  end
+
+  # 永続的セッションを破棄する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
   end
 
   # ユーザーがログインしていればtrue、その他ならfalseを返す
@@ -20,6 +41,7 @@ module SessionsHelper
 
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
   def authenticated?(remember_token)
+    return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+    attr_accessor :remember_token
     before_save { email.downcase! }
     validates :name,  presence: true, length: { maximum: 50 }
     VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
@@ -8,10 +9,19 @@ class User < ApplicationRecord
     validates :password, presence: true, length: { minimum: 6 }
     has_secure_password
 
-    # 渡された文字列のハッシュ値を返す
-    def User.digest(string)
+  # 渡された文字列のハッシュ値を返す
+  def User.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+  
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,12 +16,24 @@ class User < ApplicationRecord
     BCrypt::Password.create(string, cost: cost)
   end
 
+  # ランダムなトークンを返す
   def User.new_token
     SecureRandom.urlsafe_base64
   end
   
+  # 永続セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
+  end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
+
+  # ユーザーのログイン情報を破棄する
+  def forget
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -9,6 +9,11 @@
       =f.label :password
       =f.password_field  :password, class: 'form-control'
 
+      =f.label :remember_me, class: "checkbox inline" do
+        =f.check_box :remember_me
+        %span
+          Remember me on this computer
+
       =f.submit "Log in", class: "btn btn-primary"
 
     %p

--- a/db/migrate/20210625021925_add_remember_digest_to_users.rb
+++ b/db/migrate/20210625021925_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210612192425) do
+ActiveRecord::Schema.define(version: 20210625021925) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20210612192425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+
+  def setup
+    @user = users(:michael)
+    remember(@user)
+  end
+
+  test "current_user returns right user when session is nil" do
+    assert_equal @user, current_user
+    assert is_logged_in?
+  end
+
+  test "current_user returns nil when remember digest is wrong" do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -42,9 +42,12 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    # 2番目のウィンドウでログアウトをクリックするユーザーをシミュレートする
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+  
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -49,5 +49,21 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    # テスト内ではcookiesメソッドにシンボルを使えない
+    # assert_not_empty cookies['remember_token']
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
+  end
+
+  test "login without remembering" do
+    # クッキーを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    delete logout_path
+    # クッキーを削除してログイン
+    log_in_as(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
+  end
   
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,4 +64,8 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.valid?
   end
 
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,5 +13,19 @@ class ActiveSupport::TestCase
   def is_logged_in?
     !session[:user_id].nil?
   end
-  # Add more helper methods to be used by all tests here...
+  
+  # テストユーザーとしてログインする
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+end
+
+class ActionDispatch::IntegrationTest
+
+  # テストユーザーとしてログインする
+  def log_in_as(user, password: 'password', remember_me: '1')
+    post login_path, params: { session: { email: user.email,
+                                          password: password,
+                                          remember_me: remember_me } }
+  end
 end


### PR DESCRIPTION
# What
- クッキーには（暗号化署名された）ユーザIDとクッキー用のハッシュを使う
　- cookieメソッドにそれぞれ追加する
　　- 20年後に切れるように設定することが一般的でexpiresの設定には以下の二つが使える
　　　- ``expires: 20.years.from_now.utc``とトークン代入のときに同時に設定する
　　　- cookies.permanentとしてトークンを代入する（上記が本当に多く使われるのでメソッドが追加された）
　　- 暗号化署名には``cookies.signed``のようにすればできる．
- セッションとクッキーの使い分け
　- ログイン中はセッションが張られるので，DBへのアクセスは起きない
　- セッションが張られていない場合はクッキーを所有しているユーザならばログイン処理が自動で行われる
　　- その後にセッションが張られるのでDBとのアクセスはない．この書き・読み込みが時間かかるので使い分けが重要 
- remember_me
　- ログインを維持しますか？みたな記述の実態
　- 記憶するが選択された場合のみCookieを設定し，チェックボックスが外れているならば，Cookieを削除する