### PR TITLE
アカウント有効化リソースの作成

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActivationsController < ApplicationController
+end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,2 +1,15 @@
 class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    # アカウント有効化済みならば不正とする
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,11 +5,17 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
-      # ユーザーログイン後にユーザー情報のページにリダイレクトする
-      log_in @user
-      # remember_meチェックボックスがオンになっているかどうか
-      params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
-      redirect_back_or @user # = redirect_to user_url(user)
+      if @user.activated?
+        log_in @user
+        # remember_meチェックボックスがオンになっているかどうか
+        params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
+        redirect_back_or @user # = redirect_to user_url(user)
+      else
+        message  = "Account not activated. "
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       # エラーメッセージを作成する
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,11 +5,12 @@ class UsersController < ApplicationController
 
   def index
     # @users = User.all
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
   
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new
@@ -20,7 +21,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       # アカウント有効化メールの送信
-      UserMailer.account_activation(@user).deliver_now
+      @user.send_activation_email
       flash[:info] = "Please check your email to activate your account."
       redirect_to root_url
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,9 +19,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = "Welcome to the Sample App!"
-      redirect_to @user
+      # アカウント有効化メールの送信
+      UserMailer.account_activation(@user).deliver_now
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -26,7 +26,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,19 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
+  end
+
+  # 12章で追加
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,20 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
 
+  # アカウントを有効にする
+  def activate
+    # 以下だと二回DBへ問合せてしまっている
+    # update_attribute(:activated,    true)
+    # update_attribute(:activated_at, Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  # 有効化用のメールを送信する
+  def send_activation_email
+    # self == @user
+    UserMailer.account_activation(self).deliver_now
+  end
+
   private
     # メールアドレスをすべて小文字にする
     def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,9 +29,10 @@ class User < ApplicationRecord
   end
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest") # == user.send
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   # ユーザーのログイン情報を破棄する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,14 @@
 class User < ApplicationRecord
-    attr_accessor :remember_token
-    before_save { email.downcase! }
-    validates :name,  presence: true, length: { maximum: 50 }
-    VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-    validates :email, presence: true, length: { maximum: 255 },
-                      format: { with: VALID_EMAIL_REGEX },
-                      uniqueness: { case_sensitive: false }
-    validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
-    has_secure_password
+  attr_accessor :remember_token, :activation_token
+  before_save   :downcase_email
+  before_create :create_activation_digest
+  validates :name,  presence: true, length: { maximum: 50 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: { case_sensitive: false }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
+  has_secure_password
 
   # 渡された文字列のハッシュ値を返す
   def User.digest(string)
@@ -37,4 +38,16 @@ class User < ApplicationRecord
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  private
+    # メールアドレスをすべて小文字にする
+    def downcase_email
+      self.email.downcase!
+    end
+
+    # 有効化トークンとダイジェストを作成および代入する
+    def create_activation_digest
+      self.activation_token  = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 end

--- a/app/views/user_mailer/account_activation.html.haml
+++ b/app/views/user_mailer/account_activation.html.haml
@@ -1,0 +1,10 @@
+%h1
+  Sample App
+
+%p
+  Hi #{@user.name},
+
+%p
+  Welcome to the Sample App! Click on the link below to activate your account:
+
+= link_to "Activate", edit_account_activation_url(@user.activation_token,email: @user.email)

--- a/app/views/user_mailer/account_activation.text.haml
+++ b/app/views/user_mailer/account_activation.text.haml
@@ -1,0 +1,5 @@
+Hi #{@user.name},
+
+Welcome to the Sample App! Click on the link below to activate your account:
+
+= edit_account_activation_url(@user.activation_token, email: @user.email)

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,0 +1,4 @@
+%h1= class_name + "#" + @action
+
+%p
+  = @greeting + ", find me in app/views/user_mailer_mailer/password_reset.html.haml"

--- a/app/views/user_mailer/password_reset.text.haml
+++ b/app/views/user_mailer/password_reset.text.haml
@@ -1,0 +1,3 @@
+UserMailer#password_reset
+
+= @greeting + ", find me in app/views/user_mailer_mailer/password_reset.text.haml"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,10 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,36 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # 本番環境ではGmailを使う
+  app_name = ENV['HEROKU_APP_NAME']
+  config.action_mailer.default_url_options = { host: "#{ app_name }.herokuapp.com" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    domain:               'gmail.com',
+    port:                 587,
+    user_name:            "#{ENV['GMAIL_ACCOUNT']}@gmail.com",
+    password:             ENV['GMAIL_APP_PASS'],
+    authentication:       :login,
+    enable_starttls_auto: true
+  }
+
+  # 以下はチュートリアルの内容
+  # config.action_mailer.raise_delivery_errors = true
+  # config.action_mailer.delivery_method = :smtp
+  # app_name = ENV['APP_NAME']
+  # host = "#{ app_name }.herokuapp.com"
+  # config.action_mailer.default_url_options = { host: host }
+  # ActionMailer::Base.smtp_settings = {
+  #   :port           => ENV['MAILGUN_SMTP_PORT'],
+  #   :address        => ENV['MAILGUN_SMTP_SERVER'],
+  #   :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+  #   :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+  #   :domain         => host,
+  #   :authentication => :plain,
+  # }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'example.com' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,6 @@ Rails.application.routes.draw do
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
   resources :users
+  resources :account_activations, only: [:edit]
   
 end

--- a/db/migrate/20210703040646_add_activation_to_users.rb
+++ b/db/migrate/20210703040646_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210627135244) do
+ActiveRecord::Schema.define(version: 20210703040646) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 20210627135244) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,13 +3,17 @@ User.create!(name:  "Naoki Takashima",
   email: "naoki@example.com",
   password:              "password",
   password_confirmation: "password",
-  admin: true)
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now)
 
 User.create!(name:  "Example User",
   email: "example@railstutorial.org",
   password:              "foobar",
   password_confirmation: "foobar",
-  admin: true)
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now)
 
 99.times do |n|
 name  = Faker::Name.name
@@ -18,5 +22,7 @@ password = "password"
 User.create!(name:  name,
     email: email,
     password:              password,
-    password_confirmation: password)
+    password_confirmation: password,
+    activated: true,
+    activated_at: Time.zone.now)
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,25 +3,35 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -24,7 +24,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                          password_confirmation: "password" } }
     end
     follow_redirect!
-    assert_template 'users/show'
-    assert is_logged_in?
+    # assert_template 'users/show'
+    # assert is_logged_in?
   end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
+
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
   
   test "invalid signup information" do
     get signup_path
@@ -15,7 +19,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert'
   end
 
-  test "valid signup information" do
+  test "valid signup information with account activation" do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: { user: { name:  "Example User",
@@ -23,8 +27,24 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                          password:              "password",
                                          password_confirmation: "password" } }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    # userインスタンスにアクセス
+    user = assigns(:user)
+    assert_not user.activated?
+    # 有効化していない状態でログインしてみる
+    log_in_as(user)
+    assert_not is_logged_in?
+    # 有効化トークンが不正な場合
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # トークンは正しいがメールアドレスが無効な場合
+    get edit_account_activation_path(user.activation_token, email: 'wrong')
+    assert_not is_logged_in?
+    # 有効化トークンが正しい場合
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
-    # assert_template 'users/show'
-    # assert is_logged_in?
+    assert_template 'users/show'
+    assert is_logged_in?
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  
+  test "account_activation" do
+    user = users(:michael)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account activation", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name,               mail.body.encoded
+    assert_match user.activation_token,   mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,7 +65,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "authenticated? should return false for a user with nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
 
 end


### PR DESCRIPTION
# What
- アカウント有効化のためのメール作成
- アカウント有効化リソースにより，正しいメールアドレスのみが利用できるようにする
- 本番環境におけるメール送信（Gmailを利用）
　- ``HEROKU_APP_NAME``, ``GMAIL_ACCOUNT``, ``GMAIL_APP_PASS``の設定が必要
　- 設定方法はこの[Qiita記事](https://qiita.com/mzmz__02/items/64db94b8fc67ee0a9068)が参考になると思う

# 復習
- アカウント有効化はユーザの実体がnew関数やcreate関数によって作成された場合のみ実行されるべき
　- ということでアカウント有効化されたかどうかは更新されることがないのでupdate_attribureなどは不要
　- トークンを発行してダイジェストとして保存する（パスワードやクッキーと同じく）．このダイジェスト値が一致しているかどうかで有効化を行える．
- メールアドレスに（base64でエンコードされた）トークンを埋め込む
　- アカウントの有効化を一つのリソースとして扱うということは以下のようなeditのURLが発行されるようになる（GETで送られてくるのでPATCHのUpdateは使えないので代用）
　　- Usersリソース: ``http://www.example.com/users/1/edit``
　　- アカウント有効化リソース: ``http://www.example.com/account_activations/Base64エンコード済みトークン/edit``
　　- なので，このid部分を抜き出してDBに保存されたアカウント有効化トークンのダイジェストと比較することで有効化処理ができる
　　- さらにDBからトークンを取り出すためのユーザのメールアドレスはクエリパラメータとして渡せば容易に獲得できる．
　　- よってこれらを組み合わせたリンクをユーザのアカウント有効化リンクに提供することでアカウント有効化の処理が完了する．
　　- 最終的には``edit_account_activation_url(@user.activation_token, email: @user.email)``を用いてリンクを生成する
- hamlの勘違い
　- 出力系統は``=``をつけるのだとおもっていたけど，単に文字列の中に埋め込みたい時は``#{変数など}``とするだけで埋め込めた．．．
　- =にすると改行されるので，埋め込むときは``#{変数}``にします．
- メタプログラミング
　- 呼び出す関数を動的に変えることができる
　- 例えばRailsで配列``arr``に対してlengthを呼び出すのは``arr.length``だが，メタプログラミングだと``arr.send(:length)``や``arr.send("length")``で記述したら呼び出せる． 
- and return unlessについて
　- 演習課題で出てきた``and return unless``について再度調べたので．
　- [Qitia記事](https://qiita.com/okaryo/items/571478b78da6538da2c3)
　- 評価順序などが大事で，renderなどがtrueを返すことを活かしている．逆に，renderだけではreturnされていないということね
