### PR TITLE
パスワードの再設定

### DIFF
--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,19 @@ class PasswordResetsController < ApplicationController
   def new
   end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "Email sent with password reset instructions"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "Email address not found"
+      render 'new'
+    end
+  end
+
   def edit
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,8 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user,         only: [:edit, :update]
+  before_action :valid_user,       only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update] 
+
   def new
   end
 
@@ -17,4 +21,47 @@ class PasswordResetsController < ApplicationController
 
   def edit
   end
+
+  def update
+    if params[:user][:password].empty?
+      # DBの検証的には空文字が通るので，直接エラーを追加する
+      @user.errors.add(:password, :blank)
+      render 'edit'
+    elsif @user.update_attributes(user_params)
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = "Password has been reset."
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
+    # beforeフィルター
+
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    # 正しいユーザーかどうか確認する
+    def valid_user
+      unless (@user && @user.activated? &&
+              @user.authenticated?(:reset, params[:id]))
+        redirect_to root_url
+      end
+    end
+
+    # 期限切れかどうかを確認する
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "Password reset has expired."
+        redirect_to new_password_reset_url
+      end
+    end
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,10 +10,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: "Account activation"
   end
 
-  # 12章で追加
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: "Password reset"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email
   before_create :create_activation_digest
   validates :name,  presence: true, length: { maximum: 50 }
@@ -42,7 +42,7 @@ class User < ApplicationRecord
 
   # アカウントを有効にする
   def activate
-    # 以下だと二回DBへ問合せてしまっている
+    # 以下だと二回DBへ問合せてしまっている（検証が不要ならupdate_columnsで良い）
     # update_attribute(:activated,    true)
     # update_attribute(:activated_at, Time.zone.now)
     update_columns(activated: true, activated_at: Time.zone.now)
@@ -52,6 +52,19 @@ class User < ApplicationRecord
   def send_activation_email
     # self == @user
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    # update_attribute(:reset_digest,  User.digest(reset_token))
+    # update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,12 @@ class User < ApplicationRecord
     UserMailer.password_reset(self).deliver_now
   end
 
+  # パスワード再設定の期限が切れている場合はtrueを返す
+  def password_reset_expired?
+    # 送信時刻と今から二時間前の時刻を比較する
+    reset_sent_at < 2.hours.ago
+  end
+
   private
     # メールアドレスをすべて小文字にする
     def downcase_email

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -1,0 +1,2 @@
+%h1 PasswordResets#edit
+%p Find me in app/views/password_resets/edit.html.haml

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -1,2 +1,18 @@
-%h1 PasswordResets#edit
-%p Find me in app/views/password_resets/edit.html.haml
+-provide(:title, 'Reset password')
+%h1
+  Reset password
+
+.row
+  .col-md-6.col-md-offset-3
+    = form_for(@user, url: password_reset_path(params[:id])) do |f| 
+      = render 'shared/error_messages' 
+
+      = hidden_field_tag :email, @user.email 
+
+      = f.label :password 
+      = f.password_field :password, class: 'form-control' 
+
+      = f.label :password_confirmation, "Confirmation" 
+      = f.password_field :password_confirmation, class: 'form-control' 
+
+      = f.submit "Update password", class: "btn btn-primary" 

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -1,0 +1,2 @@
+%h1 PasswordResets#new
+%p Find me in app/views/password_resets/new.html.haml

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -1,2 +1,11 @@
-%h1 PasswordResets#new
-%p Find me in app/views/password_resets/new.html.haml
+- provide(:title, "Forgot password")
+%h1
+  Forgot password
+
+.row
+  .col-md-6.col-md-offset-3
+    = form_for(:password_reset, url: password_resets_path) do |f|
+      = f.label :email
+      = f.email_field :email, class: 'form-control'
+
+      = f.submit "Submit", class: "btn btn-primary"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -7,6 +7,7 @@
       =f.email_field  :email, class: 'form-control'
 
       =f.label :password
+      =link_to "(forgot password)", new_password_reset_path
       =f.password_field  :password, class: 'form-control'
 
       =f.label :remember_me, class: "checkbox inline" do

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,4 +1,13 @@
-%h1= class_name + "#" + @action
+%h1
+  Password reset
 
 %p
-  = @greeting + ", find me in app/views/user_mailer_mailer/password_reset.html.haml"
+  To reset your password click the link below:
+
+= link_to "Reset password", edit_password_reset_url(@user.reset_token, email: @user.email)
+
+%p
+  This link will expire in two hours.
+
+%p
+  If you did not request your password to be reset, please ignore this email and your password will stay as it is.

--- a/app/views/user_mailer/password_reset.text.haml
+++ b/app/views/user_mailer/password_reset.text.haml
@@ -1,3 +1,8 @@
-UserMailer#password_reset
+To reset your password click the link below:
 
-= @greeting + ", find me in app/views/user_mailer_mailer/password_reset.text.haml"
+= edit_password_reset_url(@user.reset_token, email: @user.email)
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
   delete '/logout',  to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets,     only: [:new, :create, :edit, :update]
   
 end

--- a/db/migrate/20210703082033_add_reset_to_users.rb
+++ b/db/migrate/20210703082033_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210703040646) do
+ActiveRecord::Schema.define(version: 20210703082033) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 20210703040646) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class PasswordResetsTest < ActionDispatch::IntegrationTest
+
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test "password resets" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    # メールアドレスが無効
+    post password_resets_path, params: { password_reset: { email: "" } }
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+    # メールアドレスが有効
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+    # パスワード再設定フォームのテスト
+    user = assigns(:user)
+    # メールアドレスが無効
+    get edit_password_reset_path(user.reset_token, email: "")
+    assert_redirected_to root_url
+    # 無効なユーザー
+    user.toggle!(:activated)
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_redirected_to root_url
+    user.toggle!(:activated) # 戻す
+    # メールアドレスが有効で、トークンが無効
+    get edit_password_reset_path('wrong token', email: user.email)
+    assert_redirected_to root_url
+    # メールアドレスもトークンも有効
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_template 'password_resets/edit'
+    assert_select "input[name=email][type=hidden][value=?]", user.email
+    # 無効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "barquux" } }
+    assert_select 'div#error_explanation'
+    # パスワードが空
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "",
+                            password_confirmation: "" } }
+    assert_select 'div#error_explanation'
+    # 有効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "foobaz" } }
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to user
+    assert_nil user.reload['reset_digest']
+  end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+
+    @user = assigns(:user)
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          params: { email: @user.email,
+                    user: { password:              "foobar",
+                            password_confirmation: "foobar" } }
+    assert_response :redirect
+    follow_redirect!
+    assert_match "expired", response.body
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -13,4 +13,15 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match user.activation_token,   mail.body.encoded
     assert_match CGI.escape(user.email),  mail.body.encoded
   end
+
+  test "password_reset" do
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
+    assert_equal "Password reset", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.reset_token,        mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
+  end
 end


### PR DESCRIPTION
# What
- パスワード再設定の処理を追加
- 時間以内に再設定用メールに添付されたリンクからパスワード変更が行われたら更新する
- アカウント有効化の応用編のような感じ

# 復習
- editで利用したメールアドレスが更新のときにも必要
　- このような場合は隠しフィールドをフォームに持たせておくことで回避する
　　- ユーザインスタンスを使って生成したフォーム（``form_for``）のhidden_filedだとparam的にはuserID>emailのような感じでアクセスする．
　　- ``hidden_field_tag``を使うことでparamから直接``:email``でアクセスできる
- 2時間以内がトークンの有効期限だけど，一度変更が成功した時点でトークンを無効にすることを忘れない
