### PR TITLE
フォロー機能の追加

### DIFF
--- a/app/assets/javascripts/relationships.coffee
+++ b/app/assets/javascripts/relationships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -154,6 +154,44 @@ aside {
   margin-top: 15px;
 }
 
+.stats {
+  overflow: auto;
+  margin-top: 0;
+  padding: 0;
+  a {
+    float: left;
+    padding: 0 10px;
+    border-left: 1px solid $gray-lighter;
+    color: gray;
+    &:first-child {
+      padding-left: 0;
+      border: 0;
+    }
+    &:hover {
+      text-decoration: none;
+      color: blue;
+    }
+  }
+  strong {
+    display: block;
+  }
+}
+
+.user_avatars {
+  overflow: auto;
+  margin-top: 10px;
+  .gravatar {
+    margin: 1px 1px;
+  }
+  a {
+    padding: 0;
+  }
+}
+
+.users.follow {
+  padding: 0;
+}
+
 /* forms */
 
 input,

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,21 @@
+class RelationshipsController < ApplicationController
+  before_action :logged_in_user
+
+  def create
+    @user = User.find(params[:followed_id])
+    current_user.follow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user }
+      format.js
+    end
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user }
+      format.js
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy, :following, :followers]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
 
@@ -48,6 +48,20 @@ class UsersController < ApplicationController
     User.find(params[:id]).destroy
     flash[:success] = "User deleted"
     redirect_to users_url
+  end
+
+  def following
+    @title = "Following"
+    @user  = User.find(params[:id])
+    @users = @user.following.paginate(page: params[:page])
+    render 'show_follow'
+  end
+
+  def followers
+    @title = "Followers"
+    @user  = User.find(params[:id])
+    @users = @user.followers.paginate(page: params[:page])
+    render 'show_follow'
   end
 
   private

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,6 @@
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,16 @@
 class User < ApplicationRecord
+  # モデル関係
   has_many :microposts, dependent: :destroy
   has_many :active_relationships, class_name:  "Relationship",
                                   foreign_key: "follower_id",
                                   dependent:   :destroy
-  has_many :following, through: :active_relationships, source: :followed
+  has_many :passive_relationships, class_name:  "Relationship",
+                                  foreign_key: "followed_id",
+                                  dependent:   :destroy
+  has_many :following, through: :active_relationships,  source: :followed
+  has_many :followers, through: :passive_relationships #, source: :follower 無くてもいい
 
+  # 検証関係
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email
   before_create :create_activation_digest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
   has_many :microposts, dependent: :destroy
+  has_many :active_relationships, class_name:  "Relationship",
+                                  foreign_key: "follower_id",
+                                  dependent:   :destroy
 
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :active_relationships, class_name:  "Relationship",
                                   foreign_key: "follower_id",
                                   dependent:   :destroy
+  has_many :following, through: :active_relationships, source: :followed
 
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email
@@ -84,6 +85,22 @@ class User < ApplicationRecord
     Micropost.where("user_id = ?", id)
   end
 
+  # ユーザーをフォローする
+  def follow(other_user)
+    # フォローの末尾に自分を追加する（SQL的にはインサートするだけなはず）
+    following << other_user
+  end
+
+  # ユーザーをフォロー解除する
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  # 現在のユーザーがフォローしてたらtrueを返す
+  def following?(other_user)
+    following.include?(other_user)
+  end
+  
   private
     # メールアドレスをすべて小文字にする
     def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,10 +85,16 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
-  # 試作feedの定義
-  # 完全な実装は次章の「ユーザーをフォローする」を参照
+  # ユーザーのステータスフィードを返す
   def feed
-    Micropost.where("user_id = ?", id)
+    # フォローしているユーザ，もしくは自分自身
+    # 下記だとDBへ二回も呼び出しがかかる
+    # Micropost.where("user_id IN (?) OR user_id = ?", following_ids, id)
+    # サブセレクト
+    following_ids = "SELECT followed_id FROM relationships
+                     WHERE follower_id = :user_id"
+    Micropost.where("user_id IN (#{following_ids})
+                     OR user_id = :user_id", user_id: id)
   end
 
   # ユーザーをフォローする

--- a/app/views/relationships/create.js.haml
+++ b/app/views/relationships/create.js.haml
@@ -1,0 +1,2 @@
+$("#follow_form").html("#{escape_javascript(render('users/unfollow'))}");
+$("#followers").html("#{@user.followers.count}");

--- a/app/views/relationships/destroy.js.haml
+++ b/app/views/relationships/destroy.js.haml
@@ -1,0 +1,2 @@
+$("#follow_form").html("#{escape_javascript(render('users/follow'))}");
+$("#followers").html("#{@user.followers.count}");

--- a/app/views/shared/_stats.html.haml
+++ b/app/views/shared/_stats.html.haml
@@ -1,0 +1,10 @@
+- @user ||= current_user
+.stats
+  %a{ href: following_user_path(@user) }
+    %strong#following.stat
+      = @user.following.count
+    following
+  %a{ href: followers_user_path(@user)}
+    %strong#followers.stat
+      = @user.followers.count
+    followers

--- a/app/views/static_pages/_user_logged_in.html.haml
+++ b/app/views/static_pages/_user_logged_in.html.haml
@@ -2,6 +2,8 @@
   %aside.col-md-4
     %section.user_info
       = render 'shared/user_info'
+    %section.stats
+      = render 'shared/stats'
     %section.micropost_form
       = render 'shared/micropost_form'
   .col-md-8

--- a/app/views/users/_follow.html.haml
+++ b/app/views/users/_follow.html.haml
@@ -1,0 +1,4 @@
+= form_for(current_user.active_relationships.build) do |f|
+  %div
+    = hidden_field_tag :followed_id, @user.id
+  = f.submit "Follow", class: "btn btn-primary"

--- a/app/views/users/_follow.html.haml
+++ b/app/views/users/_follow.html.haml
@@ -1,4 +1,4 @@
-= form_for(current_user.active_relationships.build) do |f|
+= form_for(current_user.active_relationships.build, remote: true) do |f|
   %div
     = hidden_field_tag :followed_id, @user.id
   = f.submit "Follow", class: "btn btn-primary"

--- a/app/views/users/_follow_form.html.haml
+++ b/app/views/users/_follow_form.html.haml
@@ -1,0 +1,6 @@
+- unless current_user?(@user)
+  #follow_form
+  - if current_user.following?(@user)
+    = render 'unfollow'
+  - else
+    = render 'follow'

--- a/app/views/users/_follow_form.html.haml
+++ b/app/views/users/_follow_form.html.haml
@@ -1,6 +1,6 @@
 - unless current_user?(@user)
   #follow_form
-  - if current_user.following?(@user)
-    = render 'unfollow'
-  - else
-    = render 'follow'
+    - if current_user.following?(@user)
+      = render 'unfollow'
+    - else
+      = render 'follow'

--- a/app/views/users/_unfollow.html.haml
+++ b/app/views/users/_unfollow.html.haml
@@ -1,2 +1,2 @@
-= form_for(current_user.active_relationships.find_by(followed_id: @user.id), html: { method: :delete }) do |f|
+= form_for(current_user.active_relationships.find_by(followed_id: @user.id), html: { method: :delete }, remote: true) do |f|
   = f.submit "Unfollow", class: "btn"

--- a/app/views/users/_unfollow.html.haml
+++ b/app/views/users/_unfollow.html.haml
@@ -1,0 +1,2 @@
+= form_for(current_user.active_relationships.find_by(followed_id: @user.id), html: { method: :delete }) do |f|
+  = f.submit "Unfollow", class: "btn"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,7 +5,10 @@
       %h1
         = gravatar_for @user
         = @user.name
+    %section.stats
+      = render 'shared/stats'
   .col-md-8
+    = render 'follow_form' if logged_in?
     -if @user.microposts.any?
       %h3
         Microposts (#{@user.microposts.count})

--- a/app/views/users/show_follow.html.haml
+++ b/app/views/users/show_follow.html.haml
@@ -1,0 +1,22 @@
+- provide(:title, @title)
+.row
+  %aside.col-md-4
+    %section.user_info
+      = gravatar_for @user
+      %h1= @user.name
+      %span= link_to "view my profile", @user
+      %span
+        %b
+          Microposts: #{@user.microposts.count}
+    %section.stats
+      = render 'shared/stats'
+      - if @users.any?
+        .user_avatars
+          - @users.each do |user|
+            = link_to gravatar_for(user, size: 30), user
+  .col-md-8
+    %h3= @title
+    - if @users.any?
+      %ul.users.follow
+        = render @users
+      = will_paginate

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,8 @@ module SampleApp
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # 認証トークンをremoteフォームに埋め込む
+    config.action_view.embed_authenticity_token_in_remote_forms = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,14 @@ Rails.application.routes.draw do
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
-  resources :users
+  resources :users do
+    member do
+      # /users/1/following, /users/1/followers
+      get :following, :followers
+    end
+  end
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
-  
+  resources :relationships,       only: [:create, :destroy]
 end

--- a/db/migrate/20210703145250_create_relationships.rb
+++ b/db/migrate/20210703145250_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210703111521) do
+ActiveRecord::Schema.define(version: 20210703145250) do
 
   create_table "microposts", force: :cascade do |t|
     t.text "content"
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 20210703111521) do
     t.string "picture"
     t.index ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,3 +33,12 @@ users = User.order(:created_at).take(6)
   content = Faker::Lorem.sentence(5)
   users.each { |user| user.microposts.create!(content: content) }
 end
+
+# リレーションシップ
+users = User.all
+user  = users.first
+# フォローしている，されている関係を一気に作成
+following = users[2..50]
+followers = users[3..40]
+following.each { |followed| user.follow(followed) }
+followers.each { |follower| follower.follow(user) }

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  test "create should require logged-in user" do
+    assert_no_difference 'Relationship.count' do
+      post relationships_path
+    end
+    assert_redirected_to login_url
+  end
+
+  test "destroy should require logged-in user" do
+    assert_no_difference 'Relationship.count' do
+      delete relationship_path(relationships(:one))
+    end
+    assert_redirected_to login_url
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -70,4 +70,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
+  test "should redirect following when not logged in" do
+    get following_user_path(@user)
+    assert_redirected_to login_url
+  end
+
+  test "should redirect followers when not logged in" do
+    get followers_user_path(@user)
+    assert_redirected_to login_url
+  end
+
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,9 +1,0 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  follower_id: 1
-  followed_id: 1
-
-two:
-  follower_id: 1
-  followed_id: 1

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,15 @@
+one:
+  follower: michael
+  followed: lana
+
+two:
+  follower: michael
+  followed: malory
+
+three:
+  follower: lana
+  followed: michael
+
+four:
+  follower: archer
+  followed: michael

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class FollowingTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+    log_in_as(@user)
+  end
+
+  test "following page" do
+    get following_user_path(@user)
+    assert_not @user.following.empty?
+    assert_match @user.following.count.to_s, response.body
+    @user.following.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+
+  test "followers page" do
+    get followers_user_path(@user)
+    assert_not @user.followers.empty?
+    assert_match @user.followers.count.to_s, response.body
+    @user.followers.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -4,6 +4,7 @@ class FollowingTest < ActionDispatch::IntegrationTest
 
   def setup
     @user = users(:michael)
+    @other = users(:archer)
     log_in_as(@user)
   end
 
@@ -22,6 +23,34 @@ class FollowingTest < ActionDispatch::IntegrationTest
     assert_match @user.followers.count.to_s, response.body
     @user.followers.each do |user|
       assert_select "a[href=?]", user_path(user)
+    end
+  end
+
+  test "should follow a user the standard way" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should follow a user with Ajax" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, xhr: true, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should unfollow a user the standard way" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship)
+    end
+  end
+
+  test "should unfollow a user with Ajax" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship), xhr: true
     end
   end
 end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -53,4 +53,11 @@ class FollowingTest < ActionDispatch::IntegrationTest
       delete relationship_path(relationship), xhr: true
     end
   end
+
+  test "feed on Home page" do
+    get root_path
+    @user.feed.paginate(page: 1).each do |micropost|
+      assert_match CGI.escapeHTML(micropost.content), response.body
+    end
+  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class RelationshipTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def setup
+    @relationship = Relationship.new(follower_id: users(:michael).id,
+                                     followed_id: users(:archer).id)
+  end
+
+  test "should be valid" do
+    assert @relationship.valid?
+  end
+
+  test "should require a follower_id" do
+    @relationship.follower_id = nil
+    assert_not @relationship.valid?
+  end
+
+  test "should require a followed_id" do
+    @relationship.followed_id = nil
+    assert_not @relationship.valid?
+  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -86,4 +86,22 @@ class UserTest < ActiveSupport::TestCase
     michael.unfollow(archer)
     assert_not michael.following?(archer)
   end
+
+  test "feed should have the right posts" do
+    michael = users(:michael)
+    archer  = users(:archer)
+    lana    = users(:lana)
+    # フォローしているユーザーの投稿を確認
+    lana.microposts.each do |post_following|
+      assert michael.feed.include?(post_following)
+    end
+    # 自分自身の投稿を確認
+    michael.microposts.each do |post_self|
+      assert michael.feed.include?(post_self)
+    end
+    # フォローしていないユーザーの投稿を確認
+    archer.microposts.each do |post_unfollowed|
+      assert_not michael.feed.include?(post_unfollowed)
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,6 +82,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not michael.following?(archer)
     michael.follow(archer)
     assert michael.following?(archer)
+    assert archer.followers.include?(michael)
     michael.unfollow(archer)
     assert_not michael.following?(archer)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,4 +75,14 @@ class UserTest < ActiveSupport::TestCase
       @user.destroy
     end
   end
+
+  test "should follow and unfollow a user" do
+    michael = users(:michael)
+    archer  = users(:archer)
+    assert_not michael.following?(archer)
+    michael.follow(archer)
+    assert michael.following?(archer)
+    michael.unfollow(archer)
+    assert_not michael.following?(archer)
+  end
 end


### PR DESCRIPTION
# What
- フォロー機能を実現
- フォローしているユーザがステータスフィードに表示される

# 復習
- 多対多を実現するために中間テーブルを用意する
　- この中間テーブルがチュートリアルのフォロー関係モデルになる
　- フォローしている，されているidのみが一意な対となっているテーブル
- チュートリアルにおける能動的関係と受動的関係
　- 能動的が自分から関係を作ることなのでフォローする側からの関係
　- 受動的は自分がなにもしなくても関係ができるということでフォローされる側からの関係
　- 少しややこしいので，まとめる
　　- 能動的ならばフォロされているユーザのIDが複数外部キーとして持っているようなイメージ
　　- あくまでもhas_manyなのは自分（フォローする側）．その外部キーと紐付いているのがフォローしているユーザのIDになる
　　- よって，フォローしているユーザへのアクセスがuser.followedなどで返せる（複数形問題でfollowingにしている）
　　- 中間テーブルの実現で記載しているコードやチュートリアルの能動的関係の図をじっくりみたら理解が深まる．
- 中間テーブルの実現（ユーザが複数のフォロワーを持つ，その逆も然り）
　- ``has_many through``を使う．
　　- まず上記の能動，受動どちらかでhas_manyを書く．（逆の関係も同じことをするだけ）
　　- 上記のhas_manyで持ったテーブルを元に**逆側関係**を``has_many through``で定義
　　- 探すときの名前を上書きする場合はテーブルのid名をsourceとして指定する（テーブルではfollowedだけど実際に使うときはfollowingにしたい，複数形でhas_manyは書くので，上書きする場合にはどの属性を指定するのかを明確にしてあげる）
　　- Railsとかの良いところは英語が実直に意味として残るところで，結局のところ``has_many through``は「ある関係を通してXXXを複数持っている」みたいなときに使える．逆の関係を構築するときに使えるアプローチというイメージ良さそう．
```
has_many :active_relationships, class_name:  "Relationship",
                         foreign_key: "follower_id",
                         dependent:   :destroy
has_many :following, through: :active_relationships, source: :followed
```
- 関係を削除する
　- 関係自体にidが振られているので，削除するのは簡単で，idをキーとしてDELETEのSQLを実行するだけ
- ルーティングにおけるmemberやcollection
　- RESTとしてのルーティングの中でidを間に挟むか挟まないかの違い
　- この[Qiita記事](https://qiita.com/k152744/items/141345e34fc0095217fe)がわかりやすい
- コントローラーの役割の再確認
　- フォロー関係のコントローラーを作成するにあたって，あ，そうかそうかとわかってるはずのMVCの関係を忘れかけていたので一応メモ
　- ルーティングで飛んでくる先はコントローラーで，モデルにアクセスする必要があるならばアクセスして必要なデータを読み書き．最後にviewがあればそれを返す．
　- たまに忘れるけど，セッションコントローラーはログイン部分を担うコントローラーでログインとともにセッションを管理するのでこのような名前になっている
- Ajax通信の実現
　- formの作成でAjaxを使うのはほぼ当たり前で，Railsは``form_for``のメソッドに``remote: true``を設定するだけでAjax通信になる
　- jsのフォーマットを指定して直接DOMをいじる場合はあくまでもscriptを埋め込むわけではないので，直書きでhamlを書いて``.js.haml``を作成する
```
# ERB
$("#follow_form").html("<%= escape_javascript(render('users/unfollow')) %>");
$("#followers").html('<%= @user.followers.count %>');
# HAML
$("#follow_form").html("#{escape_javascript(render('users/unfollow'))}");
$("#followers").html("#{@user.followers.count}");
```
- サブセレクト
　- SQLで問合せした結果をさらに使ってDBへアクセスするならばサブセレクトを利用するのが良い
　- セレクト文がセレクト文の中に入っているイメージ．ここらへんがDB側で最適化されている
　- ただサブセレクトだけでいくらでもスケールできるなどということはないので，繊細にスケーリングは行わないといけない（非同期に実行させるなど）
 